### PR TITLE
Fix mismatch in README and actual code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module.exports = {
         // Make gzip compressed (default: false)
         gzip: true,
         // Make file public (default: false)
-        public: true,
+        makePublic: true,
       },
     }),
   ],


### PR DESCRIPTION
This problem took me 4 hours to debug-- in the actual code, you are looking for `makePublic` in the uploadOptions, not `public`. But the documentation says to use `public`. Because it defaults to false, any settings here are silently ignored.

Either change it in the README (as done in this PR) or change it in the use case, please!