### PR TITLE
FIX - Error: connect EHOSTDOWN 169.254.169.254:80

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
-    "@google-cloud/storage": "^0.4.0",
+    "@google-cloud/storage": "^1.5.0"
     "babel-polyfill": "^6.16.0",
     "bluebird": "^3.4.6",
     "lodash.merge": "^4.6.0",


### PR DESCRIPTION
Updates to most recent version of base lib which is `"@google-cloud/storage": "1.5.2"`

https://github.com/googleapis/nodejs-storage 


Solves: https://github.com/syndbg/webpack-google-cloud-storage-plugin/issues/8 