### PR TITLE
Support attaching file metadata, and constrain upload concurrency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 indent_size = 2
+
+[*.js]
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -19,17 +19,15 @@ module.exports = {
   plugins: [
     new WebpackGoogleCloudStoragePlugin({
       directory: './src',
-      // NOTE: Array of filenames to include in the uploading process
+      // NOTE: Array of regexes matching filenames to include in the uploading process
       include: ['app.js'],
-      // NOTE: Array of filenames to exclude in the uploading process
+      // NOTE: Array of regexes matching filenames to exclude in the uploading process
       exclude: ['cats.js'],
-      // NOTE: Options passed directly to
-      // Google cloud Node Storage client.
-      // This is mostly authentication-wise.
-      // For more information:
+      // NOTE: Options passed directly to Google cloud Node Storage client. This is 
+      // mostly for authentication-wise. For more information:
       // https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/storage#authentication
       storageOptions: {
-        // project id is optional if you specify a keyFilename
+        // projectId is optional if you specify a keyFilename
         projectId: 'grape-spaceship-123',
         // keyFilename: '/path/to/keyfile.json'
         // keyFilename: './examples/my-credentials.json', // note: Filename, not FileName

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ module.exports = {
       // For more information:
       // https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/storage#authentication
       storageOptions: {
+        // project id is optional if you specify a keyFilename
         projectId: 'grape-spaceship-123',
         // keyFilename: '/path/to/keyfile.json'
-        // keyFileName: './examples/my-credentials.json',
+        // keyFilename: './examples/my-credentials.json', // note: Filename, not FileName
         // key: 'mykey',
         // credentials: require('/path/to/credentials.json'),
       },
@@ -47,6 +48,14 @@ module.exports = {
         destinationNameFn: file =>
            path.join('assets', file.path)
         ,
+        // Available properties in returned object are defined here;
+        // https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON
+        // It will be passed into 'upload' here:
+        // https://github.com/googleapis/nodejs-storage/blob/master/samples/files.js#L116
+        metadataFn: file => ({
+          // cache it a little longer!
+          cacheControl: 'public, max-age=31536000',
+        }),
         // Make gzip compressed (default: false)
         gzip: true,
         // Make file public (default: false)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-google-cloud-storage-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A Webpack plugin to upload assets in Google Cloud Storage.",
   "main": "dist/webpack-google-cloud-storage-plugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "NODE_ENV=production webpack --config webpack.config.js",
+    "prepare": "npm run build",
     "example": "cd examples && webpack --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch",
     "lint": "eslint --quiet --fix --ext .js .",

--- a/src/index.js
+++ b/src/index.js
@@ -51,11 +51,11 @@ module.exports = class WebpackGoogleCloudStoragePlugin {
 
   /**
    * Return an object following this schema:
-   * 
-   * - https://cloud.google.com/nodejs/docs/reference/storage/2.0.x/Bucket#upload 
+   *
+   * - https://cloud.google.com/nodejs/docs/reference/storage/2.0.x/Bucket#upload
    * - https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON
    * - Example: https://github.com/googleapis/nodejs-storage/blob/master/samples/files.js#L119
-   * 
+   *
    * @param {*} file { path: string }
    */
   static defaultMetadataFn(file) {

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ module.exports = class WebpackGoogleCloudStoragePlugin {
    *
    * @param {*} file { path: string }
    */
-  static defaultMetadataFn(file) {
-    return {}
+  static defaultMetadataFn(/* file */) {
+    return {};
   }
 
   static getAssetFiles({ assets }) {
@@ -179,12 +179,12 @@ module.exports = class WebpackGoogleCloudStoragePlugin {
     // http://bluebirdjs.com/docs/api/promise.map.html#map-option-concurrency
     return Promise.map(files,
       file => bucket.upload(file.path, {
-          destination: this.uploadOptions.destinationNameFn(file),
-          gzip: this.uploadOptions.gzip || false,
-          public: this.uploadOptions.makePublic || false,
-          resumable: this.uploadOptions.resumable,
-          metadata: this.uploadOptions.metadataFn(file)
-        }),
+        destination: this.uploadOptions.destinationNameFn(file),
+        gzip: this.uploadOptions.gzip || false,
+        public: this.uploadOptions.makePublic || false,
+        resumable: this.uploadOptions.resumable,
+        metadata: this.uploadOptions.metadataFn(file),
+      }),
       { concurrency: 10 });
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ module.exports = class WebpackGoogleCloudStoragePlugin {
           gzip: PropTypes.bool,
           public: PropTypes.bool,
           destinationNameFn: PropTypes.func,
+          metadataFn: PropTypes.func,
           makePublic: PropTypes.bool,
           resumable: PropTypes.bool,
         }
@@ -177,16 +178,13 @@ module.exports = class WebpackGoogleCloudStoragePlugin {
     // see https://hackernoon.com/concurrency-control-in-promises-with-bluebird-977249520f23
     // http://bluebirdjs.com/docs/api/promise.map.html#map-option-concurrency
     return Promise.map(files,
-      file =>
-      bucket.upload(
-        file.path,
-        {
+      file => bucket.upload(file.path, {
           destination: this.uploadOptions.destinationNameFn(file),
           gzip: this.uploadOptions.gzip || false,
           public: this.uploadOptions.makePublic || false,
           resumable: this.uploadOptions.resumable,
-        }
-      ),
+          metadata: this.uploadOptions.metadataFn(file)
+        }),
       { concurrency: 10 });
   }
 };


### PR DESCRIPTION
I'm uploading rather a few (~250 of them) static files and that got stuck on uploading them with this plugin.

I'd also like to serve them with a CDN with nice cache headers.