### PR TITLE
Invalidate CDN after upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ module.exports = {
         concurrency: 5,
       },
     }),
+    // Optional, used to invalidate the cache in Google Cloud CDN:
+    // See https://cloud.google.com/cdn/docs/invalidating-cached-content#gclou
+    cdnCacheInvalidateOptions: {
+      // The URL map is likely the name of your Cloud CDN Origin
+      // Run `gcloud compute url-maps list` to see a list of your URL maps
+      urlMap: 'my-url-map',
+      // (Optional) If only a certain directory needs to be invalidated, list it here:
+      path: '/*', // This is the default.
+      // (Optional) Or if there are multiple paths you want to invalidate:
+      paths: ['/', '/index.html', '/manifest.json']
+    },
   ],
 };
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ module.exports = {
 
 Check out the examples folder for a working demo.
 
-Add your credentials to `storageOptions` and set `uploadOptions`.
+Add your credentials to `storageOptions` and set `uploadOptions`. Configure `cdnCacheInvalidateOptions` if you need
+to invalidate a Google CDN cache.
 
 Then you can run the demo webpack using `npm run example`.

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -58,8 +58,33 @@ module.exports = {
         // E.g: app.js => assets/v1/app.js,
         // file is an object with { name:, path: }.
         destinationNameFn: file =>
-           path.join('assets', file.path)
+          path.join('assets', file.path)
         ,
+        // You can use the metadataFn to set file metadata based on the path:
+        // See: https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON for all
+        // options, though cacheControl is likely to be the most relevant:
+        metadataFn: (file) => {
+          if (/.html$/.test(file.path)) {
+            return {
+              cacheControl: 'no-store',
+            };
+          }
+
+          return {
+            cacheControl: 'public, max-age=60',
+          };
+        },
+      },
+      // Optional, used to invalidate the cache in Google Cloud CDN:
+      // See https://cloud.google.com/cdn/docs/invalidating-cached-content#gclou
+      cdnCacheInvalidateOptions: {
+        // The URL map is likely the name of your Cloud CDN Origin
+        // Run `gcloud compute url-maps list` to see a list of your URL maps
+        urlMap: 'my-storage-load-balancer',
+        // (Optional) If only a certain directory needs to be invalidated, list it here:
+        // path: '/*', // This is the default.
+        // (Optional) Or if there are multiple paths you want to invalidate:
+        // paths: ['/', '/index.html', '/manifest.json'],
       },
     }),
   ],

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@google-cloud/storage": "^1.5.0",
     "babel-polyfill": "^6.16.0",
     "bluebird": "^3.4.6",
+    "googleapis": "^73.0.0",
     "lodash.merge": "^4.6.0",
     "prop-types": "^0.2.0",
     "recursive-readdir": "^2.1.0"


### PR DESCRIPTION
This pull request implements the feature requested in #18 by adding `cdnCacheInvalidateOptions` to the configuration, which allows you to specify the Cloud CDN URL Map and a path (or paths) to invalidate after uploading files to the Cloud Storage bucket.

I also expanded the example config to show how using `metadataFn` works, since if you're worried about caching, you'll likely want to set custom `cacheControl` metadata.